### PR TITLE
support markdown process

### DIFF
--- a/src/tests.rs
+++ b/src/tests.rs
@@ -182,11 +182,11 @@ dogs"
 #[test]
 fn literal_hash() {
     assert_eq!(
-        crate::process_str(" ## literal hash", &mut crate::Context::new()).unwrap(),
-        " ## literal hash\n"
+        crate::process_str("## literal hash", &mut crate::Context::new()).unwrap(),
+        "## literal hash\n"
     );
     assert_eq!(
-        crate::process_str("## literal hash", &mut crate::Context::new()).unwrap(),
-        "# literal hash\n"
+        crate::process_str("#* literal hash", &mut crate::Context::new()).unwrap(),
+        "#* literal hash\n"
     );
 }


### PR DESCRIPTION
## [Fix]
Fix the processing of markdown syntax `##` or `#*` will remove a `#,` the previous space # is not very beautiful
## [Test]
cargo test passed